### PR TITLE
ベンチマークの結果出力をより良くする

### DIFF
--- a/grademe.sh
+++ b/grademe.sh
@@ -38,22 +38,26 @@ print_benchmark_output () {
         | grep -v leaks \
         | awk '{
             if ($5 < $2) {
-                printf "%-20s%8s %s", $1, $2, $3
+                printf "%-22s%8s %s", $1, $2, $3
                 printf " | "
-                printf "\033[32m%-20s%8s %s\033[0m", $4, $5, $6
+                printf "\033[32m%-22s%8s %s\033[0m", $4, $5, $6
             }
-            else if ($5 > $2 * 20)
-            {
-                printf "\033[32m%-20s%8s %s\033[0m", $1, $2, $3
+            else if ($5 > $2 * 20) {
+                printf "\033[32m%-22s%8s %s\033[0m", $1, $2, $3
                 printf " | "
-                printf "\033[31m%-20s%8s %s\033[0m", $4, $5, $6
+                printf "\033[31m%-22s%8s %s\033[0m", $4, $5, $6
+            }
+            else if ($5 > $2) {
+                printf "\033[32m%-22s%8s %s\033[0m", $1, $2, $3
+                printf " | "
+                printf "%-22s%8s %s", $4, $5, $6
             }
             else {
-                printf "\033[32m%-20s%8s %s\033[0m", $1, $2, $3
+                printf "%-22s%8s %s", $1, $2, $3
                 printf " | "
-                printf "%-20s%8s %s", $4, $5, $6
+                printf "%-22s%8s %s", $4, $5, $6
             }
-            printf "\n"
+            printf "\033[2m  (x%.3f)\033[0m\n", $5 / $2
         }'
 }
 


### PR DESCRIPTION
## 変更内容
- 関数名の表示幅を修正（20文字 -> 22文字）
  - `vector::get_allocator` で表示が崩れていたため
- stlとftのtimeが同じ時、stlが緑色になっていたのを修正
  - timeが同じ時、どちらも白色にするように
- `ftのtime / stlのtime` を右側にグレーで表示するように

## 出力例
![output](https://user-images.githubusercontent.com/42476527/140693778-6235ca3f-5ade-4714-80a1-94bd0d7a5735.png)
